### PR TITLE
SEC-704: Migrate gradle-build-action to gradle/actions/setup-gradle and pin it

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -13,14 +13,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           cache: 'npm'
           node-version: 20
       - name: Set up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -27,10 +27,11 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
         shell: bash
-      - name: Build Android test app
-        uses: gradle/gradle-build-action@v2
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96
         with:
           gradle-version: wrapper
-          arguments: -PnewArchEnabled=${{matrix.newArchEnabled}} --no-daemon clean build check test
-          build-root-directory: example/android
+      - name: Build and Test Android App
+        working-directory: example/android
+        run: ./gradlew -PnewArchEnabled=${{matrix.newArchEnabled}} --no-daemon clean build check test
     timeout-minutes: 60

--- a/.github/workflows/detox.yml
+++ b/.github/workflows/detox.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: 'macOS-latest'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
       - name: Setup - Install NPM Dependencies

--- a/.github/workflows/ios-ci.yml
+++ b/.github/workflows/ios-ci.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/macos-ci.yml
+++ b/.github/workflows/macos-ci.yml
@@ -9,9 +9,9 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,11 +7,11 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3.0.14
+    - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Hello 👋, this issue has been opened for more than 2 months with no activity on it. If the issue is still here, please keep in mind that we need community support and help to fix it! Just comment something like _still searching for solutions_ and if you found one, please open a pull request! You have 7 days until this gets closed automatically'
         stale-pr-message: 'Hello 👋, this PR has been opened for more than 2 months with no activity on it. If you think this is a mistake please comment and ping a maintainer to get this merged ASAP! Thanks for contributing! You have 7 days until this gets closed automatically'
-        exempt-issue-label: 'Keep opened'
-        exempt-pr-label: 'Keep opened'
+        exempt-issue-labels: 'Keep opened'
+        exempt-pr-labels: 'Keep opened'
         remove-stale-when-updated: true

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -7,17 +7,17 @@ jobs:
     runs-on: windows-2022
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       name: Checkout Code
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
       with:
         node-version: '20'
         cache: 'npm'
 
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.1.3
+      uses: microsoft/setup-msbuild@6fb02220983dee41ce7ae257b6f4d8f9bf5ed4ce
       with:
         vs-version: '[17.0,)'
         msbuild-architecture: x64


### PR DESCRIPTION
https://front.atlassian.net/browse/SEC-704
Now that we have allowlisted all existing GH actions, we should work to pin all to a full length SHA commit as a security measure in response to the tj-actions incident.

Safe to revert.

Pinning this one separately since it involves an action migration and is a little higher risk.